### PR TITLE
Update setuphandler for Plone 6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.2 (unreleased)
+------------------
+- Updated setuphandlers.py for Plone 6
+
 1.1.dev0 (unreleased)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '1.1.dev0'
+version = '1.2'
 shortdesc = 'Google Tag Manager Intergation'
 longdesc = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 longdesc += open(os.path.join(os.path.dirname(__file__), 'CHANGES.rst')).read()

--- a/src/bda/plone/gtm/profiles.zcml
+++ b/src/bda/plone/gtm/profiles.zcml
@@ -28,8 +28,5 @@
     description="Google Tag Manager Integration"
     provides="Products.GenericSetup.interfaces.EXTENSION" />
 
-  <!-- Hide profiles/products from Quick Installer -->
-  <utility factory=".setuphandlers.HiddenProfiles" name="bda.plone.gtm" />
-  <utility factory=".setuphandlers.HiddenProducts" name="bda.plone.gtm" />
 
 </configure>

--- a/src/bda/plone/gtm/setuphandlers.py
+++ b/src/bda/plone/gtm/setuphandlers.py
@@ -1,21 +1,17 @@
 # -*- coding:utf-8 -*-
-from Products.CMFPlone import interfaces as Plone
-from Products.CMFQuickInstallerTool import interfaces as QuickInstaller
+from Products.CMFPlone.interfaces import INonInstallable
 from zope.interface import implementer
 
 
-@implementer(Plone.INonInstallable)
+@implementer(INonInstallable)
 class HiddenProfiles(object):
-
     def getNonInstallableProfiles(self):
-        """Do not show on Plone's list of installable profiles.
-        """
+        """Hide uninstall profile from site-creation and quickinstaller."""
         return ['bda.plone.gtm:install-base']
 
 
-@implementer(QuickInstaller.INonInstallable)
+@implementer(INonInstallable)
 class HiddenProducts(object):
-
     def getNonInstallableProducts(self):
         """Do not show on QuickInstaller's list of installable products.
         """


### PR DESCRIPTION
In Plone 6 the `Products.CMFQuickInstallerTool.interfaces.INonInstallable` moved to  `Products.CMFPlone.interfaces.INonInstallable `